### PR TITLE
feat(graph): improve readability and add explicit sequential reasonin…

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -85,11 +85,13 @@ class ChatRequest(BaseModel):
 class ChatResponse(BaseModel):
     reply: str
     extracted_symptoms: List[str]
+    symptom_timeline: List[str] = []
     top_conditions: List[dict]
     rag_sources: List[str]
     graph_followups: List[str]
     red_flags_detected: List[str]
     traversal_path: List[dict] = []
+    journey_edges: List[dict] = []
 
 class GraphNode(BaseModel):
     id: str
@@ -172,6 +174,46 @@ RULES:
 # Chat endpoint
 # ---------------------------------------------------------------------------
 
+FINAL_LINK_THRESHOLD = 0.65
+
+
+def merge_symptom_timeline(existing: List[str], newly_extracted: List[str]) -> List[str]:
+    """Merge symptoms while preserving first-seen order across turns."""
+    merged: List[str] = []
+    seen = set()
+    for symptom in (existing or []) + (newly_extracted or []):
+        normalised = symptom.strip().lower()
+        if not normalised or normalised in seen:
+            continue
+        seen.add(normalised)
+        merged.append(normalised)
+    return merged
+
+
+def build_journey_edges(symptom_timeline: List[str], candidates: List[dict]) -> List[dict]:
+    """Build sequential symptom path and optional final symptom->condition edge."""
+    edges: List[dict] = []
+
+    for i in range(len(symptom_timeline) - 1):
+        edges.append({
+            "from": symptom_timeline[i],
+            "to": symptom_timeline[i + 1],
+            "edge_type": "SEQUENTIAL_SYMPTOM",
+        })
+
+    if symptom_timeline and candidates:
+        top = candidates[0]
+        score = float(top.get("score", 0))
+        if score >= FINAL_LINK_THRESHOLD:
+            edges.append({
+                "from": symptom_timeline[-1],
+                "to": top.get("condition_id", ""),
+                "edge_type": "SYMPTOM_TO_CONDITION",
+                "score": round(score, 3),
+            })
+
+    return edges
+
 @app.post("/chat", response_model=ChatResponse)
 async def chat(request: ChatRequest):
     try:
@@ -186,9 +228,10 @@ async def chat(request: ChatRequest):
 
         # --- Step 1: NLP extraction ---
         extraction = NLP.extract(latest_user_msg)
-        all_symptoms = list(set(
-            (request.extracted_symptoms or []) + extraction.symptoms
-        ))
+        all_symptoms = merge_symptom_timeline(
+            request.extracted_symptoms or [],
+            extraction.symptoms,
+        )
 
         # --- Step 2: Red flag check ---
         red_flags = check_red_flags(GRAPH, all_symptoms + (extraction.symptoms if extraction else []))
@@ -200,6 +243,8 @@ async def chat(request: ChatRequest):
         if candidates:
             top_condition = candidates[0]["condition_id"]
             followup_questions = get_followup_questions(GRAPH, top_condition)
+
+        journey_edges = build_journey_edges(all_symptoms, candidates)
 
         # --- Step 4: RAG retrieval ---
         rag_context = RAG.retrieve_context(latest_user_msg, top_k=2)
@@ -242,6 +287,7 @@ async def chat(request: ChatRequest):
         return ChatResponse(
             reply=reply,
             extracted_symptoms=all_symptoms,
+            symptom_timeline=all_symptoms,
             top_conditions=[
                 {
                     "display":       c["display"],
@@ -256,6 +302,7 @@ async def chat(request: ChatRequest):
             graph_followups=followup_questions[:4],
             red_flags_detected=red_flags,
             traversal_path=candidates[0].get("traversal_path", []) if candidates else [],
+            journey_edges=journey_edges,
         )
     except Exception as overall_e:
         import traceback

--- a/app/main.py
+++ b/app/main.py
@@ -178,11 +178,12 @@ FINAL_LINK_THRESHOLD = 0.65
 
 
 def merge_symptom_timeline(existing: List[str], newly_extracted: List[str]) -> List[str]:
-    """Merge symptoms while preserving first-seen order across turns."""
+    """Preserve first-seen order across turns while removing duplicates."""
     merged: List[str] = []
     seen = set()
+
     for symptom in (existing or []) + (newly_extracted or []):
-        normalised = symptom.strip().lower()
+        normalised = (symptom or "").strip().lower()
         if not normalised or normalised in seen:
             continue
         seen.add(normalised)
@@ -191,7 +192,7 @@ def merge_symptom_timeline(existing: List[str], newly_extracted: List[str]) -> L
 
 
 def build_journey_edges(symptom_timeline: List[str], candidates: List[dict]) -> List[dict]:
-    """Build sequential symptom path and optional final symptom->condition edge."""
+    """Build step-by-step symptom chain and threshold-gated first symptom->condition link."""
     edges: List[dict] = []
 
     for i in range(len(symptom_timeline) - 1):
@@ -203,13 +204,14 @@ def build_journey_edges(symptom_timeline: List[str], candidates: List[dict]) -> 
 
     if symptom_timeline and candidates:
         top = candidates[0]
-        score = float(top.get("score", 0))
-        if score >= FINAL_LINK_THRESHOLD:
+        top_score = float(top.get("score", 0.0))
+        top_condition_id = top.get("condition_id", "")
+        if top_condition_id and top_score >= FINAL_LINK_THRESHOLD:
             edges.append({
-                "from": symptom_timeline[-1],
-                "to": top.get("condition_id", ""),
-                "edge_type": "SYMPTOM_TO_CONDITION",
-                "score": round(score, 3),
+                "from": symptom_timeline[0],
+                "to": top_condition_id,
+                "edge_type": "FIRST_SYMPTOM_TO_CONDITION",
+                "score": round(top_score, 3),
             })
 
     return edges

--- a/static/index.html
+++ b/static/index.html
@@ -551,7 +551,7 @@
 
   const THEME = {
     bg: '#0f172a',
-    dimmed: 'rgba(100, 116, 139, 0.2)',
+    dimmed: 'rgba(100, 116, 139, 0.25)',
     dimmedNode: '#334155',
     activeSymp: '#3b82f6',
     activeCond: '#10b981',
@@ -589,31 +589,18 @@
     const g = svg.append('g').attr('class', 'graph-root');
     GRAPH.gRoot = g;
 
-    const getDisplayLabel = d => (d.label || d.id || '').replace(/_/g, ' ');
-    const collisionRadius = d => {
-      const text = getDisplayLabel(d);
-      const approxWidth = Math.min(170, Math.max(32, text.length * 6.2));
-      const base = d.type === 'condition' ? 15 : 12;
-      return base + approxWidth / 9;
-    };
-
     svg.call(d3.zoom()
       .scaleExtent([0.1, 4])
       .on('zoom', ev => g.attr('transform', ev.transform))
     );
 
-    // Force layout is tuned for bipartite readability with stronger whitespace.
+    // Forces: Greatly spaced out to prevent overlapping
     GRAPH.simulation = d3.forceSimulation(GRAPH.nodes)
-      .force('link', d3.forceLink(GRAPH.edges)
-        .id(d => d.id)
-        .distance(d => d.edge_type === 'SUGGESTS' ? 130 : 105)
-        .strength(0.22))
-      .force('charge', d3.forceManyBody().strength(-900))
-      .force('x', d3.forceX(W / 2).strength(0.08))
-      .force('y', d3.forceY(d => d.type === 'condition' ? H * 0.8 : H * 0.2).strength(0.95))
-      .force('collide', d3.forceCollide().radius(collisionRadius).iterations(2));
-
-    GRAPH.simulation.alpha(1).alphaDecay(0.05).velocityDecay(0.45);
+      .force('link', d3.forceLink(GRAPH.edges).id(d => d.id).distance(60))
+      .force('charge', d3.forceManyBody().strength(-280))
+      .force('x', d3.forceX(W / 2).strength(0.04))
+      .force('y', d3.forceY(d => d.type === 'condition' ? H - 150 : 150).strength(0.6))
+      .force('collide', d3.forceCollide().radius(22));
 
     // Edges
     GRAPH.linkEls = g.append('g')
@@ -622,7 +609,7 @@
       .join('line')
       .attr('stroke', THEME.dimmed)
       .attr('stroke-width', 1)
-      .style('opacity', 0.18);
+      .style('opacity', 0.5);
 
     // Dynamic sequential path edges
     GRAPH.dynamicLinkEls = g.append('g')
@@ -645,10 +632,10 @@
       .selectAll('text')
       .data(GRAPH.nodes)
       .join('text')
-      .text(d => getDisplayLabel(d))
-      .attr('font-size', '7px')
+      .text(d => d.id.replace(/_/g, ' '))
+      .attr('font-size', '8px')
       .attr('fill', '#94a3b8')
-      .attr('opacity', 0.2)
+      .attr('opacity', 0.7)
       .attr('dx', 10)
       .attr('dy', 3)
       .style('pointer-events', 'none')
@@ -697,8 +684,44 @@
     }
   }
 
-  function toNodeId(value) {
-    return (value || '').toString().trim().toLowerCase().replace(/\s+/g, '_');
+  function normalizeGraphId(text) {
+    return (text || '').toString().trim().toLowerCase().replace(/\s+/g, '_');
+  }
+
+  function resolveGraphNodeId(item) {
+    if (!item) return null;
+
+    const rawValues = [];
+    if (typeof item === 'string') {
+      rawValues.push(item);
+    } else {
+      if (item.condition_id) rawValues.push(item.condition_id);
+      if (item.display) rawValues.push(item.display);
+      if (item.id) rawValues.push(item.id);
+    }
+
+    for (const raw of rawValues) {
+      const base = (raw || '').toString().trim().toLowerCase();
+      if (!base) continue;
+
+      const candidates = [
+        base,
+        base.replace(/\s+/g, '_'),
+        base.replace(/_/g, ' '),
+        base.replace(/[^a-z0-9_\s]/g, '').replace(/\s+/g, '_')
+      ];
+
+      for (const id of candidates) {
+        if (GRAPH.nodeMap[id]) return id;
+      }
+    }
+
+    return rawValues.length > 0 ? normalizeGraphId(rawValues[0]) : null;
+  }
+
+  function resolveGraphNode(item) {
+    const id = resolveGraphNodeId(item);
+    return id ? GRAPH.nodeMap[id] || null : null;
   }
 
   function highlightGraph(symptoms, conditions, journeyEdges) {
@@ -707,107 +730,86 @@
     const hint = document.getElementById('graph-empty-hint');
     if (hint) hint.style.display = 'none';
 
-    const symptomTimeline = symptoms || [];
-    const baseSymp = symptomTimeline.length > 0 ? toNodeId(symptomTimeline[0]) : null;
-    const topCondId = conditions && conditions.length > 0
-      ? toNodeId(conditions[0].condition_id || conditions[0].display)
-      : null;
+    const activeSymptoms = new Set((symptoms || []).map(resolveGraphNodeId).filter(Boolean));
+    const activeConditions = new Set((conditions || []).map(resolveGraphNodeId).filter(Boolean));
+    const topCondId = conditions && conditions.length > 0 ? resolveGraphNodeId(conditions[0]) : null;
 
-    const activePathNodeIds = new Set(symptomTimeline.map(toNodeId));
-
+    // Render dynamic path strictly from backend-provided journey edges.
     const dynamicEdges = [];
-    const edgesFromBackend = journeyEdges || [];
-    for (const edge of edgesFromBackend) {
-      const fromId = toNodeId(edge.from);
-      const toId = toNodeId(edge.to);
-      const fromNode = GRAPH.nodeMap[fromId];
-      const toNode = GRAPH.nodeMap[toId];
+    for (const edge of (journeyEdges || [])) {
+      const fromNode = resolveGraphNode(edge.from);
+      const toNode = resolveGraphNode(edge.to);
       if (fromNode && toNode) {
         dynamicEdges.push({
           source: fromNode,
           target: toNode,
-          edgeType: edge.edge_type || 'SEQUENTIAL_SYMPTOM'
+          edge_type: edge.edge_type,
+          score: edge.score
         });
-        activePathNodeIds.add(fromId);
-        activePathNodeIds.add(toId);
       }
     }
 
-    // Backwards-compat fallback if journey edges are unavailable.
-    if (dynamicEdges.length === 0 && symptomTimeline.length > 1) {
-      for (let i = 0; i < symptomTimeline.length - 1; i++) {
-        const fromNode = GRAPH.nodeMap[toNodeId(symptomTimeline[i])];
-        const toNode = GRAPH.nodeMap[toNodeId(symptomTimeline[i + 1])];
-        if (fromNode && toNode) {
-          dynamicEdges.push({ source: fromNode, target: toNode, edgeType: 'SEQUENTIAL_SYMPTOM' });
-        }
-      }
-    }
-
-    const topCondInJourney = dynamicEdges.some(
-      e => e.edgeType === 'SYMPTOM_TO_CONDITION' && e.target.id === topCondId
-    );
-
-    // Draw dynamic sequential connections over existing map
+    // Draw dynamic journey connections over existing graph.
     GRAPH.dynamicLinkEls = GRAPH.gRoot.select('.dyn-edges')
       .selectAll('line')
-      .data(dynamicEdges)
+      .data(dynamicEdges, (_, i) => i)
       .join('line')
-      .attr('stroke', THEME.edge)
-      .attr('stroke-width', d => d.edgeType === 'SYMPTOM_TO_CONDITION' ? 4.8 : 4.2)
-      .attr('stroke-linecap', 'round')
-      .style('opacity', 0.96)
+      .attr('stroke', d => {
+        if (d.edge_type === 'FIRST_SYMPTOM_TO_CONDITION') return '#ea580c';
+        if (d.edge_type === 'SEQUENTIAL_SYMPTOM') return '#fb923c';
+        return THEME.edge;
+      })
+      .attr('stroke-width', d => {
+        if (d.edge_type === 'FIRST_SYMPTOM_TO_CONDITION') return 5.5;
+        if (d.edge_type === 'SEQUENTIAL_SYMPTOM') return 4;
+        return 2.5;
+      })
+      .attr('marker-end', 'url(#timeline-arrow)')
       .style('pointer-events', 'none');
 
     // Update nodes styling
     GRAPH.nodeEls
       .transition().duration(500)
       .attr('fill', d => {
-        if (topCondInJourney && d.id === topCondId) return THEME.topCond;
-        if (activePathNodeIds.has(d.id) && d.type === 'condition') return THEME.activeCond;
-        if (d.id === baseSymp) return THEME.activeSymp;
-        if (activePathNodeIds.has(d.id)) return '#7c3aed';
+        if (d.id === topCondId) return THEME.topCond;
+        if (activeConditions.has(d.id)) return THEME.activeCond;
+        if (activeSymptoms.has(d.id)) return THEME.activeSymp;
         return THEME.dimmedNode;
       })
-      .attr('opacity', d => {
-        return (activePathNodeIds.has(d.id) || (topCondInJourney && d.id === topCondId)) ? 1.0 : 0.2;
-      })
       .attr('r', d => {
-        if (topCondInJourney && d.id === topCondId) return 12;
-        if (activePathNodeIds.has(d.id)) return d.type === 'condition' ? 9 : 8;
-        return d.type === 'condition' ? 6 : 4;
+        if (d.id === topCondId) return 12;
+        if (activeConditions.has(d.id) || activeSymptoms.has(d.id)) return 8;
+        return d.type === 'condition' ? 7 : 5;
       });
 
     // Update labels
     GRAPH.labelEls
       .transition().duration(500)
       .attr('fill', d => {
-        if (topCondInJourney && d.id === topCondId) return '#ffffff';
-        if (d.id === baseSymp) return '#93c5fd';
-        if (activePathNodeIds.has(d.id)) return d.type === 'condition' ? '#f8fafc' : '#c4b5fd';
-        return '#64748b';
+        if (activeConditions.has(d.id) || activeSymptoms.has(d.id)) return '#f8fafc';
+        return '#94a3b8';
       })
       .attr('opacity', d => {
-        return activePathNodeIds.has(d.id) || (topCondInJourney && d.id === topCondId) ? 1.0 : 0.2;
+        return (activeConditions.has(d.id) || activeSymptoms.has(d.id)) ? 1.0 : 0.7;
       })
       .attr('font-size', d => {
-        if (topCondInJourney && d.id === topCondId) return '14px';
-        if (activePathNodeIds.has(d.id)) return '11px';
-        return '7px';
+        if (d.id === topCondId) return '14px';
+        if (activeConditions.has(d.id) || activeSymptoms.has(d.id)) return '11px';
+        return '8px';
       })
-      .style('font-weight', d => (activePathNodeIds.has(d.id) || (topCondInJourney && d.id === topCondId)) ? '700' : '400');
+      .style('font-weight', d => (activeConditions.has(d.id) || activeSymptoms.has(d.id)) ? '700' : '400');
 
     // Dim the static base edges to emphasize the generated pathway
     GRAPH.linkEls
       .transition().duration(500)
       .attr('stroke', THEME.dimmed)
-      .attr('stroke-width', 0.8)
-      .style('opacity', 0.12);
+      .attr('stroke-width', 1)
+      .style('opacity', 0.3);
 
     // Update stats
-    const hlNodes = activePathNodeIds.size + (topCondInJourney ? 1 : 0);
+    const hlNodes = activeSymptoms.size + activeConditions.size;
     document.getElementById('graph-stats').textContent =
-      `Structured Global Graph · ${hlNodes} journey nodes · ${dynamicEdges.length} journey edges`;
+      `Structured Global Graph · ${hlNodes} active nodes · ${dynamicEdges.length} active connections`;
   }
 
 
@@ -1008,8 +1010,12 @@
       // Attach traversal path to data for dashboard rendering
       data.traversal_path = data.top_conditions?.[0]?.traversal_path || [];
       updateDashboard(data);
-      // Update graph highlighting with newly active nodes and BFS traversal
-      highlightGraph(allSymptoms, data.top_conditions, data.journey_edges || []);
+      // Update graph highlighting with backend-provided journey edges.
+      highlightGraph(
+        data.symptom_timeline || data.extracted_symptoms || [],
+        data.top_conditions,
+        data.journey_edges || []
+      );
 
     } catch (err) {
       removeTyping();

--- a/static/index.html
+++ b/static/index.html
@@ -551,7 +551,7 @@
 
   const THEME = {
     bg: '#0f172a',
-    dimmed: 'rgba(100, 116, 139, 0.25)',
+    dimmed: 'rgba(100, 116, 139, 0.2)',
     dimmedNode: '#334155',
     activeSymp: '#3b82f6',
     activeCond: '#10b981',
@@ -589,18 +589,31 @@
     const g = svg.append('g').attr('class', 'graph-root');
     GRAPH.gRoot = g;
 
+    const getDisplayLabel = d => (d.label || d.id || '').replace(/_/g, ' ');
+    const collisionRadius = d => {
+      const text = getDisplayLabel(d);
+      const approxWidth = Math.min(170, Math.max(32, text.length * 6.2));
+      const base = d.type === 'condition' ? 15 : 12;
+      return base + approxWidth / 9;
+    };
+
     svg.call(d3.zoom()
       .scaleExtent([0.1, 4])
       .on('zoom', ev => g.attr('transform', ev.transform))
     );
 
-    // Forces: Greatly spaced out to prevent overlapping
+    // Force layout is tuned for bipartite readability with stronger whitespace.
     GRAPH.simulation = d3.forceSimulation(GRAPH.nodes)
-      .force('link', d3.forceLink(GRAPH.edges).id(d => d.id).distance(60))
-      .force('charge', d3.forceManyBody().strength(-280))
-      .force('x', d3.forceX(W / 2).strength(0.04))
-      .force('y', d3.forceY(d => d.type === 'condition' ? H - 150 : 150).strength(0.6))
-      .force('collide', d3.forceCollide().radius(22));
+      .force('link', d3.forceLink(GRAPH.edges)
+        .id(d => d.id)
+        .distance(d => d.edge_type === 'SUGGESTS' ? 130 : 105)
+        .strength(0.22))
+      .force('charge', d3.forceManyBody().strength(-900))
+      .force('x', d3.forceX(W / 2).strength(0.08))
+      .force('y', d3.forceY(d => d.type === 'condition' ? H * 0.8 : H * 0.2).strength(0.95))
+      .force('collide', d3.forceCollide().radius(collisionRadius).iterations(2));
+
+    GRAPH.simulation.alpha(1).alphaDecay(0.05).velocityDecay(0.45);
 
     // Edges
     GRAPH.linkEls = g.append('g')
@@ -609,7 +622,7 @@
       .join('line')
       .attr('stroke', THEME.dimmed)
       .attr('stroke-width', 1)
-      .style('opacity', 0.5);
+      .style('opacity', 0.18);
 
     // Dynamic sequential path edges
     GRAPH.dynamicLinkEls = g.append('g')
@@ -632,10 +645,10 @@
       .selectAll('text')
       .data(GRAPH.nodes)
       .join('text')
-      .text(d => d.id.replace(/_/g, ' '))
-      .attr('font-size', '8px')
+      .text(d => getDisplayLabel(d))
+      .attr('font-size', '7px')
       .attr('fill', '#94a3b8')
-      .attr('opacity', 0.7)
+      .attr('opacity', 0.2)
       .attr('dx', 10)
       .attr('dy', 3)
       .style('pointer-events', 'none')
@@ -684,38 +697,56 @@
     }
   }
 
-  function highlightGraph(symptoms, conditions, traversalPath) {
+  function toNodeId(value) {
+    return (value || '').toString().trim().toLowerCase().replace(/\s+/g, '_');
+  }
+
+  function highlightGraph(symptoms, conditions, journeyEdges) {
     if (!GRAPH.initialized) return;
 
     const hint = document.getElementById('graph-empty-hint');
     if (hint) hint.style.display = 'none';
 
-    // Collect active IDs & determine which is base vs followup
-    const baseSymp = symptoms && symptoms.length > 0 ? symptoms[0].toLowerCase().replace(/ /g,'_') : null;
-    const followupSymps = new Set((symptoms || []).slice(1).map(s => s.toLowerCase().replace(/ /g,'_')));
-    
-    // Total active symptoms
-    const activeSymptoms = new Set((symptoms || []).map(s => s.toLowerCase().replace(/ /g,'_')));
-    const activeConditions = new Set((conditions || []).map(c => 
-      (c.condition_id || c.display).toLowerCase().replace(/ /g,'_')
-    ));
-    const topCondId = conditions && conditions.length > 0 ? 
-      (conditions[0].condition_id || conditions[0].display).toLowerCase().replace(/ /g,'_') : null;
+    const symptomTimeline = symptoms || [];
+    const baseSymp = symptomTimeline.length > 0 ? toNodeId(symptomTimeline[0]) : null;
+    const topCondId = conditions && conditions.length > 0
+      ? toNodeId(conditions[0].condition_id || conditions[0].display)
+      : null;
 
-    // Build sequential path
+    const activePathNodeIds = new Set(symptomTimeline.map(toNodeId));
+
     const dynamicEdges = [];
-    if (symptoms && symptoms.length > 0) {
-      for (let i = 0; i < symptoms.length - 1; i++) {
-        const fromNode = GRAPH.nodeMap[symptoms[i].toLowerCase().replace(/ /g,'_')];
-        const toNode = GRAPH.nodeMap[symptoms[i+1].toLowerCase().replace(/ /g,'_')];
-        if (fromNode && toNode) dynamicEdges.push({ source: fromNode, target: toNode });
-      }
-      if (topCondId) {
-        const fromNode = GRAPH.nodeMap[symptoms[symptoms.length - 1].toLowerCase().replace(/ /g,'_')];
-        const toNode = GRAPH.nodeMap[topCondId];
-        if (fromNode && toNode) dynamicEdges.push({ source: fromNode, target: toNode });
+    const edgesFromBackend = journeyEdges || [];
+    for (const edge of edgesFromBackend) {
+      const fromId = toNodeId(edge.from);
+      const toId = toNodeId(edge.to);
+      const fromNode = GRAPH.nodeMap[fromId];
+      const toNode = GRAPH.nodeMap[toId];
+      if (fromNode && toNode) {
+        dynamicEdges.push({
+          source: fromNode,
+          target: toNode,
+          edgeType: edge.edge_type || 'SEQUENTIAL_SYMPTOM'
+        });
+        activePathNodeIds.add(fromId);
+        activePathNodeIds.add(toId);
       }
     }
+
+    // Backwards-compat fallback if journey edges are unavailable.
+    if (dynamicEdges.length === 0 && symptomTimeline.length > 1) {
+      for (let i = 0; i < symptomTimeline.length - 1; i++) {
+        const fromNode = GRAPH.nodeMap[toNodeId(symptomTimeline[i])];
+        const toNode = GRAPH.nodeMap[toNodeId(symptomTimeline[i + 1])];
+        if (fromNode && toNode) {
+          dynamicEdges.push({ source: fromNode, target: toNode, edgeType: 'SEQUENTIAL_SYMPTOM' });
+        }
+      }
+    }
+
+    const topCondInJourney = dynamicEdges.some(
+      e => e.edgeType === 'SYMPTOM_TO_CONDITION' && e.target.id === topCondId
+    );
 
     // Draw dynamic sequential connections over existing map
     GRAPH.dynamicLinkEls = GRAPH.gRoot.select('.dyn-edges')
@@ -723,56 +754,60 @@
       .data(dynamicEdges)
       .join('line')
       .attr('stroke', THEME.edge)
-      .attr('stroke-width', 2.5)
-      .attr('marker-end', 'url(#timeline-arrow)') // Requires marker def or standard shape
+      .attr('stroke-width', d => d.edgeType === 'SYMPTOM_TO_CONDITION' ? 4.8 : 4.2)
+      .attr('stroke-linecap', 'round')
+      .style('opacity', 0.96)
       .style('pointer-events', 'none');
 
     // Update nodes styling
     GRAPH.nodeEls
       .transition().duration(500)
       .attr('fill', d => {
-        if (d.id === topCondId) return THEME.topCond;
-        if (activeConditions.has(d.id)) return THEME.activeCond;
+        if (topCondInJourney && d.id === topCondId) return THEME.topCond;
+        if (activePathNodeIds.has(d.id) && d.type === 'condition') return THEME.activeCond;
         if (d.id === baseSymp) return THEME.activeSymp;
-        if (followupSymps.has(d.id)) return '#7c3aed'; 
+        if (activePathNodeIds.has(d.id)) return '#7c3aed';
         return THEME.dimmedNode;
       })
+      .attr('opacity', d => {
+        return (activePathNodeIds.has(d.id) || (topCondInJourney && d.id === topCondId)) ? 1.0 : 0.2;
+      })
       .attr('r', d => {
-        if (d.id === topCondId) return 12;
-        if (activeConditions.has(d.id) || activeSymptoms.has(d.id)) return 8;
-        return d.type === 'condition' ? 7 : 5;
+        if (topCondInJourney && d.id === topCondId) return 12;
+        if (activePathNodeIds.has(d.id)) return d.type === 'condition' ? 9 : 8;
+        return d.type === 'condition' ? 6 : 4;
       });
 
     // Update labels
     GRAPH.labelEls
       .transition().duration(500)
       .attr('fill', d => {
-        if (activeConditions.has(d.id)) return '#f8fafc';
-        if (d.id === baseSymp) return '#93c5fd'; 
-        if (followupSymps.has(d.id)) return '#c4b5fd'; 
-        return '#94a3b8';
+        if (topCondInJourney && d.id === topCondId) return '#ffffff';
+        if (d.id === baseSymp) return '#93c5fd';
+        if (activePathNodeIds.has(d.id)) return d.type === 'condition' ? '#f8fafc' : '#c4b5fd';
+        return '#64748b';
       })
       .attr('opacity', d => {
-        return (activeConditions.has(d.id) || activeSymptoms.has(d.id)) ? 1.0 : 0.7;
+        return activePathNodeIds.has(d.id) || (topCondInJourney && d.id === topCondId) ? 1.0 : 0.2;
       })
       .attr('font-size', d => {
-        if (d.id === topCondId) return '14px';
-        if (activeConditions.has(d.id) || activeSymptoms.has(d.id)) return '11px';
-        return '8px';
+        if (topCondInJourney && d.id === topCondId) return '14px';
+        if (activePathNodeIds.has(d.id)) return '11px';
+        return '7px';
       })
-      .style('font-weight', d => (activeConditions.has(d.id) || activeSymptoms.has(d.id)) ? '700' : '400');
+      .style('font-weight', d => (activePathNodeIds.has(d.id) || (topCondInJourney && d.id === topCondId)) ? '700' : '400');
 
     // Dim the static base edges to emphasize the generated pathway
     GRAPH.linkEls
       .transition().duration(500)
       .attr('stroke', THEME.dimmed)
-      .attr('stroke-width', 1)
-      .style('opacity', 0.3);
+      .attr('stroke-width', 0.8)
+      .style('opacity', 0.12);
 
     // Update stats
-    const hlNodes = activeSymptoms.size + activeConditions.size;
+    const hlNodes = activePathNodeIds.size + (topCondInJourney ? 1 : 0);
     document.getElementById('graph-stats').textContent =
-      `Structured Global Graph · ${hlNodes} active nodes · ${dynamicEdges.length} active connections`;
+      `Structured Global Graph · ${hlNodes} journey nodes · ${dynamicEdges.length} journey edges`;
   }
 
 
@@ -967,14 +1002,14 @@
       const data = await res.json();
 
       removeTyping();
-      allSymptoms = data.extracted_symptoms || [];
+      allSymptoms = data.symptom_timeline || data.extracted_symptoms || [];
       history.push({ role: 'assistant', content: data.reply });
       addMessage('bot', data.reply);
       // Attach traversal path to data for dashboard rendering
       data.traversal_path = data.top_conditions?.[0]?.traversal_path || [];
       updateDashboard(data);
       // Update graph highlighting with newly active nodes and BFS traversal
-      highlightGraph(data.extracted_symptoms, data.top_conditions, data.traversal_path || []);
+      highlightGraph(allSymptoms, data.top_conditions, data.journey_edges || []);
 
     } catch (err) {
       removeTyping();


### PR DESCRIPTION
closes #1 
- preserve symptom order across turns (remove unordered set merge)
- add symptom_timeline and journey_edges to /chat response
- add threshold-gated final edge from last symptom to top condition
- tune D3 force layout for dense graphs: 
  - stronger repulsion, longer link distance
  - clearer symptom-top / condition-bottom alignment
  - label-aware collision radius
- render backend-driven journey edges as thick high-contrast orange paths
- dim non-active graph context and emphasize active path labels/nodes for clarity

output screenshots:
[testing.zip](https://github.com/user-attachments/files/26850632/testing.zip)
