### PR TITLE
feat: add fuzzy matching for symptom extraction via rapidfuzz

### DIFF
--- a/app/core/nlp_extractor.py
+++ b/app/core/nlp_extractor.py
@@ -18,6 +18,15 @@ import csv
 import os
 from typing import NamedTuple
 
+try:
+    from rapidfuzz import process as fuzz_process, fuzz
+    _FUZZY_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _FUZZY_AVAILABLE = False
+
+# Minimum similarity score (0-100) to accept a fuzzy match
+FUZZY_THRESHOLD = 85
+
 
 # ---------------------------------------------------------------------------
 # 1. Synonym generator — turns dataset symptom names into lexicon entries
@@ -205,6 +214,9 @@ class SymptomExtractor:
             self.phrase_to_symptom.keys(), key=len, reverse=True
         )
 
+        # Pre-build a flat list of all phrases for fuzzy candidate lookup
+        self._all_phrases: list[str] = list(self.phrase_to_symptom.keys())
+
         self.negation_patterns = re.compile(
             r"\b(no|not|without|don't have|doesn't have|haven't|hasn't|never|"
             r"no sign of|denies|absence of)\b",
@@ -213,6 +225,24 @@ class SymptomExtractor:
 
         print(f"[NLP] Lexicon loaded: {len(lexicon)} canonical symptoms, "
               f"{len(self.phrase_to_symptom)} total phrases")
+
+    def _fuzzy_match_token(self, token: str) -> tuple[str, str] | None:
+        """
+        Try to fuzzy-match a single token (or short phrase) against all known
+        lexicon phrases. Returns (matched_phrase, canonical) or None.
+        """
+        if not _FUZZY_AVAILABLE or len(token) < 3:
+            return None
+        result = fuzz_process.extractOne(
+            token,
+            self._all_phrases,
+            scorer=fuzz.WRatio,
+            score_cutoff=FUZZY_THRESHOLD,
+        )
+        if result is None:
+            return None
+        matched_phrase, score, _ = result
+        return matched_phrase, self.phrase_to_symptom[matched_phrase]
 
     def extract(self, text: str) -> ExtractionResult:
         text_lower = text.lower()
@@ -256,6 +286,47 @@ class SymptomExtractor:
 
                 start = idx + 1
 
+        # ── Fuzzy fallback pass ──────────────────────────────────────────
+        # Tokenize the text into word n-grams (1–3 words) that weren't
+        # already covered by exact matching, then fuzzy-match each against
+        # the full phrase lexicon.
+        if _FUZZY_AVAILABLE:
+            words = re.findall(r"[a-z']+", text_lower)
+            # Generate trigrams → bigrams → unigrams (longest wins)
+            candidates: list[tuple[int, str]] = []
+            for n in (3, 2, 1):
+                for i in range(len(words) - n + 1):
+                    ngram = " ".join(words[i: i + n])
+                    approx_pos = text_lower.find(ngram)
+                    if approx_pos == -1:
+                        continue
+                    positions = set(range(approx_pos, approx_pos + len(ngram)))
+                    if positions & matched_positions:
+                        continue  # already matched exactly
+                    candidates.append((approx_pos, ngram))
+
+            seen_positions: set[int] = set()
+            for approx_pos, ngram in candidates:
+                positions = set(range(approx_pos, approx_pos + len(ngram)))
+                if positions & seen_positions:
+                    continue
+
+                hit = self._fuzzy_match_token(ngram)
+                if hit is None:
+                    continue
+
+                matched_phrase, canonical = hit
+                seen_positions |= positions
+                matched_positions |= positions
+                raw_mentions.append(ngram)
+
+                if is_negated(approx_pos):
+                    if canonical not in negated_symptoms:
+                        negated_symptoms.append(canonical)
+                else:
+                    if canonical not in found_symptoms:
+                        found_symptoms.append(canonical)
+
         return ExtractionResult(
             symptoms     = found_symptoms,
             raw_mentions = raw_mentions,
@@ -280,6 +351,10 @@ if __name__ == "__main__":
         "I feel really tired, have a fever and chills, my body is aching",
         "I have no fever but my throat is sore and it hurts to swallow",
         "burning sensation when I pee and I need to go to the toilet frequently",
+        # Typo / misspelling tests
+        "I have a bad fevver and feel very tierd",
+        "my throte is sore and I keep sneazing",
+        "I feel nauseus and have diahrea",
     ]
     for t in tests:
         r = extractor.extract(t)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ fastapi
 uvicorn[standard]
 python-dotenv
 networkx
+rapidfuzz
 
 # For production-grade RAG (upgrade from TF-IDF):
 # sentence-transformers


### PR DESCRIPTION
- Integrate rapidfuzz with 85% WRatio similarity threshold
- Add _fuzzy_match_token() for n-gram based fuzzy lookup
- Fuzzy fallback pass in extract() covers unmatched tokens after exact matching
- Graceful degradation if rapidfuzz is not installed
- Add rapidfuzz to requirements.txt
- Extend self-test with typo inputs (fevver, tierd, sneazing, etc.)