### PR TITLE
Add .env.example and update README (fixes #24)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Required: Get your Groq API key from https://console.groq.com/
+GROQ_API_KEY=your_groq_api_key_here
+
+# Optional: Gemini API key (only needed if using Gemini model path)
+GEMINI_API_KEY=your_gemini_key_here_or_leave_blank

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ Create/Edit the [`.env`](file:///.env) file at the project root:
 GEMINI_API_KEY=your_gemini_key_optional
 GROQ_API_KEY=your_groq_api_key_here
 ```
+Copy the example environment file and fill in your keys:
 
+cp .env.example .env
 ---
 
 ##  Running the System


### PR DESCRIPTION
This PR adds a .env.example file with placeholder API keys and updates the README to include instructions for setting up environment variables.

This improves onboarding by helping contributors understand how to configure the required API keys.

Fixes #24