### PR TITLE
Replace character-window negation with spaCy dependency parsing

### DIFF
--- a/app/core/nlp_extractor.py
+++ b/app/core/nlp_extractor.py
@@ -17,6 +17,7 @@ import re
 import csv
 import os
 from typing import NamedTuple
+import spacy
 
 
 # ---------------------------------------------------------------------------
@@ -211,21 +212,51 @@ class SymptomExtractor:
             re.IGNORECASE
         )
 
+        # Initialize spaCy for dependency-based negation parsing
+        try:
+            self.nlp = spacy.load("en_core_web_sm")
+        except OSError:
+            print("[NLP] Model 'en_core_web_sm' not found. Please run 'python -m spacy download en_core_web_sm'")
+            self.nlp = None
+
         print(f"[NLP] Lexicon loaded: {len(lexicon)} canonical symptoms, "
               f"{len(self.phrase_to_symptom)} total phrases")
 
+    def _is_negated(self, doc, start_char: int, end_char: int) -> bool:
+        """
+        Determines if a symptom mention is negated using the dependency tree.
+        """
+        if not doc:
+            return False
+
+        # Find tokens that overlap with the character range [start_char, end_char)
+        symptom_tokens = [t for t in doc if t.idx >= start_char and t.idx < end_char]
+        if not symptom_tokens:
+            # Fallback for tokens that might start slightly before start_char (e.g. whitespace)
+            symptom_tokens = [t for t in doc if t.idx + len(t.text) > start_char and t.idx < end_char]
+
+        negation_words = {"no", "not", "without", "never", "deny", "denies", "absence", "negative"}
+
+        for token in symptom_tokens:
+            # 1. Direct children negation (e.g., "no fever")
+            if any(child.dep_ == "neg" or child.lemma_.lower() in negation_words for child in token.children):
+                return True
+            
+            # 2. Check ancestors and their children (siblings/head negation)
+            curr = token
+            while curr != curr.head:
+                curr = curr.head
+                # If the parent has a negation child (e.g. "don't HAVE headache")
+                if any(child.dep_ == "neg" or child.lemma_.lower() in negation_words for child in curr.children):
+                    return True
+                if curr.pos_ == "VERB":
+                    break
+
+        return False
+
     def extract(self, text: str) -> ExtractionResult:
         text_lower = text.lower()
-
-        # Detect negation windows (40 chars after negation keyword)
-        negated_spans: set[tuple] = set()
-        for match in self.negation_patterns.finditer(text_lower):
-            start = match.end()
-            end   = min(start + 40, len(text_lower))
-            negated_spans.add((start, end))
-
-        def is_negated(pos: int) -> bool:
-            return any(s <= pos <= e for s, e in negated_spans)
+        doc = self.nlp(text) if self.nlp else None
 
         found_symptoms:   list[str] = []
         negated_symptoms: list[str] = []
@@ -247,7 +278,7 @@ class SymptomExtractor:
                 raw_mentions.append(text[idx: idx + len(phrase)])
                 matched_positions |= positions
 
-                if is_negated(idx):
+                if self._is_negated(doc, idx, idx + len(phrase)):
                     if canonical not in negated_symptoms:
                         negated_symptoms.append(canonical)
                 else:
@@ -273,18 +304,26 @@ if __name__ == "__main__":
     csv_p = str(_here / "data" / "symptom_disease.csv")
 
     extractor = SymptomExtractor(csv_path=csv_p)
+    
+    print("\n" + "="*40)
+    print("      SYMPTOM EXTRACTION TESTER")
+    print("="*40)
+    print("Type your symptoms (or 'quit' to exit)")
 
-    tests = [
-        "I have a terrible headache on one side that's throbbing, sensitive to light",
-        "I've been vomiting and have diarrhoea, also stomach cramps",
-        "I feel really tired, have a fever and chills, my body is aching",
-        "I have no fever but my throat is sore and it hurts to swallow",
-        "burning sensation when I pee and I need to go to the toilet frequently",
-    ]
-    for t in tests:
-        r = extractor.extract(t)
-        print(f"Input:    {t[:65]}...")
-        print(f"  Found:   {r.symptoms}")
-        if r.negated:
-            print(f"  Negated: {r.negated}")
-        print()
+    while True:
+        try:
+            t = input("\n[Input]: ").strip()
+            if not t or t.lower() in ["quit", "exit", "q"]:
+                print("Exiting...")
+                break
+                
+            r = extractor.extract(t)
+            print(f"  [Found]:   {r.symptoms}")
+            if r.negated:
+                print(f"  [Negated]: {r.negated}")
+            if not r.symptoms and not r.negated:
+                print("  [Result]:  No symptoms detected.")
+                
+        except KeyboardInterrupt:
+            print("\nExiting...")
+            break

--- a/app/core/nlp_extractor.py
+++ b/app/core/nlp_extractor.py
@@ -242,11 +242,14 @@ class SymptomExtractor:
             if any(child.dep_ == "neg" or child.lemma_.lower() in negation_words for child in token.children):
                 return True
             
-            # 2. Check ancestors and their children (siblings/head negation)
+            # 2. Check ancestors (e.g., "denies pain" or "don't HAVE headache")
             curr = token
             while curr != curr.head:
                 curr = curr.head
-                # If the parent has a negation child (e.g. "don't HAVE headache")
+                # Check if the ancestor itself is a negation word (e.g. "DENIES pain")
+                if curr.lemma_.lower() in negation_words:
+                    return True
+                # If the ancestor has a negation child (e.g. "don't HAVE headache")
                 if any(child.dep_ == "neg" or child.lemma_.lower() in negation_words for child in curr.children):
                     return True
                 if curr.pos_ == "VERB":

--- a/app/core/nlp_extractor.py
+++ b/app/core/nlp_extractor.py
@@ -19,6 +19,15 @@ import os
 from typing import NamedTuple
 import spacy
 
+try:
+    from rapidfuzz import process as fuzz_process, fuzz
+    _FUZZY_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _FUZZY_AVAILABLE = False
+
+# Minimum similarity score (0-100) to accept a fuzzy match
+FUZZY_THRESHOLD = 85
+
 
 # ---------------------------------------------------------------------------
 # 1. Synonym generator — turns dataset symptom names into lexicon entries
@@ -206,6 +215,9 @@ class SymptomExtractor:
             self.phrase_to_symptom.keys(), key=len, reverse=True
         )
 
+        # Pre-build a flat list of all phrases for fuzzy candidate lookup
+        self._all_phrases: list[str] = list(self.phrase_to_symptom.keys())
+
         self.negation_patterns = re.compile(
             r"\b(no|not|without|don't have|doesn't have|haven't|hasn't|never|"
             r"no sign of|denies|absence of)\b",
@@ -257,6 +269,24 @@ class SymptomExtractor:
 
         return False
 
+    def _fuzzy_match_token(self, token: str) -> tuple[str, str] | None:
+        """
+        Try to fuzzy-match a single token (or short phrase) against all known
+        lexicon phrases. Returns (matched_phrase, canonical) or None.
+        """
+        if not _FUZZY_AVAILABLE or len(token) < 3:
+            return None
+        result = fuzz_process.extractOne(
+            token,
+            self._all_phrases,
+            scorer=fuzz.WRatio,
+            score_cutoff=FUZZY_THRESHOLD,
+        )
+        if result is None:
+            return None
+        matched_phrase, score, _ = result
+        return matched_phrase, self.phrase_to_symptom[matched_phrase]
+
     def extract(self, text: str) -> ExtractionResult:
         text_lower = text.lower()
         doc = self.nlp(text) if self.nlp else None
@@ -289,6 +319,47 @@ class SymptomExtractor:
                         found_symptoms.append(canonical)
 
                 start = idx + 1
+
+        # ── Fuzzy fallback pass ──────────────────────────────────────────
+        # Tokenize the text into word n-grams (1–3 words) that weren't
+        # already covered by exact matching, then fuzzy-match each against
+        # the full phrase lexicon.
+        if _FUZZY_AVAILABLE:
+            words = re.findall(r"[a-z']+", text_lower)
+            # Generate trigrams → bigrams → unigrams (longest wins)
+            candidates: list[tuple[int, str]] = []
+            for n in (3, 2, 1):
+                for i in range(len(words) - n + 1):
+                    ngram = " ".join(words[i: i + n])
+                    approx_pos = text_lower.find(ngram)
+                    if approx_pos == -1:
+                        continue
+                    positions = set(range(approx_pos, approx_pos + len(ngram)))
+                    if positions & matched_positions:
+                        continue  # already matched exactly
+                    candidates.append((approx_pos, ngram))
+
+            seen_positions: set[int] = set()
+            for approx_pos, ngram in candidates:
+                positions = set(range(approx_pos, approx_pos + len(ngram)))
+                if positions & seen_positions:
+                    continue
+
+                hit = self._fuzzy_match_token(ngram)
+                if hit is None:
+                    continue
+
+                matched_phrase, canonical = hit
+                seen_positions |= positions
+                matched_positions |= positions
+                raw_mentions.append(ngram)
+
+                if self._is_negated(doc, approx_pos, approx_pos + len(ngram)):
+                    if canonical not in negated_symptoms:
+                        negated_symptoms.append(canonical)
+                else:
+                    if canonical not in found_symptoms:
+                        found_symptoms.append(canonical)
 
         return ExtractionResult(
             symptoms     = found_symptoms,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,11 @@ google-genai
 fastapi
 uvicorn[standard]
 python-dotenv
+groq
+google-genai
+fastapi
+uvicorn[standard]
+python-dotenv
 networkx
 
 # For production-grade RAG (upgrade from TF-IDF):
@@ -10,6 +15,5 @@ networkx
 # chromadb
 
 # For production-grade NLP (upgrade from keyword matching):
-# spacy
-# # then run: python -m spacy download en_core_web_sm
-
+spacy
+# python -m spacy download en_core_web_sm


### PR DESCRIPTION
**Problem**
The previous negation detection logic used a fixed 40-character lookahead window from any negation keyword (e.g., "no", "not"). This caused "context leakage," where symptoms in separate sentences were incorrectly marked as negated if they were physically close to a negation word.

**Solution**
I have integrated spaCy's dependency parser to replace the distance-based logic with grammatical relationship detection.
- Dependency Tree Navigation: The SymptomExtractor now checks if a detected symptom is grammatically linked to a negation modifier (neg dependency) or a negation determiner (like "no").
- Sentence Boundary Awareness: Natural sentence stops now prevent negation leakage; a "no" in one sentence will no longer affect symptoms in the next.
- Robust Keyword Detection: Enhanced the logic to handle parent-level negations (e.g., "don't have [symptom]") and sibling modifications.

**Changes**
1. Modified app/core/nlp_extractor.py:
2. Added spaCy initialization (en_core_web_sm).
3. Implemented _is_negated() method using the dependency tree.
4. Added an interactive testing CLI loop for manual verification.
5. Updated requirements.txt:
6. Uncommented spacy and added the model download command.

**Verification Results**
Successfully tested with interactive manual input:

<img width="907" height="475" alt="image" src="https://github.com/user-attachments/assets/b607bbc8-a26d-471f-b976-aba283ec1c2d" />
