### PR TITLE
Fix BFS traversal to handle multiple symptom matches and remove premature break

### DIFF
--- a/app/core/knowledge_graph.py
+++ b/app/core/knowledge_graph.py
@@ -196,9 +196,11 @@ def traverse_graph(G: nx.DiGraph, symptoms: list[str]) -> list[dict]:
                 if u in node or node in u:
                     matched_nodes.append(node)
                     found = True
-                    break
         if not found:
             unmatched.append(u)
+
+
+        matched_nodes = list(set(matched_nodes))
 
     if not matched_nodes:
         return []


### PR DESCRIPTION
### Fix: Early-Exit Bug in Symptom Node Matching that caused incomplete BFS traversal

#### Problem
The traversal logic was stopping after the first substring match due to a premature `break` statement.  
This caused incomplete symptom node collection and resulted in BFS missing relevant condition paths.

#### Solution
- Removed the early `break` in the substring matching loop
- Enabled collection of all matching symptom nodes (multi-source traversal)
- Deduplicated matched nodes using a set
- Ensured BFS starts from all relevant symptom nodes

#### Result
- Multiple symptom matches are now correctly captured
- BFS traversal covers all relevant paths
- Improved accuracy and completeness of condition ranking

#### Notes
- Changes are limited to traversal logic only
- No modifications were made to unrelated components (e.g., AI/Groq integration)

---

Closes #12 