### PR TITLE
fix: remove early exit in symptom node matching loop

### DIFF
--- a/app/core/knowledge_graph.py
+++ b/app/core/knowledge_graph.py
@@ -181,23 +181,27 @@ def traverse_graph(G: nx.DiGraph, symptoms: list[str]) -> list[dict]:
 
     # -- Step 1: Match user symptoms to graph symptom nodes --
     matched_nodes: list[str] = []
+    matched_set: set[str] = set()   # tracks already-added nodes for O(1) dedup
     unmatched: list[str] = []
 
     for user_sym in symptoms:
         u = user_sym.lower().strip()
         # Exact match
         if u in G and G.nodes[u].get("node_type") == "symptom":
-            matched_nodes.append(u)
+            if u not in matched_set:
+                matched_nodes.append(u)
+                matched_set.add(u)
             continue
-        # Substring match — collect ALL matching nodes, not just the first
+        # Substring match — iterate every node to collect ALL matches,
+        # not just the first one.
         found = False
         for node in G.nodes:
             if G.nodes[node].get("node_type") == "symptom":
                 if u in node or node in u:
-                    if node not in matched_nodes:  # avoid duplicates
-                        matched_nodes.append(node)
                     found = True
-                    # ✅ No break — keep scanning for more matches
+                    if node not in matched_set:   # dedup check before append
+                        matched_nodes.append(node)
+                        matched_set.add(node)
         if not found:
             unmatched.append(u)
 

--- a/app/core/knowledge_graph.py
+++ b/app/core/knowledge_graph.py
@@ -189,14 +189,15 @@ def traverse_graph(G: nx.DiGraph, symptoms: list[str]) -> list[dict]:
         if u in G and G.nodes[u].get("node_type") == "symptom":
             matched_nodes.append(u)
             continue
-        # Substring match
+        # Substring match — collect ALL matching nodes, not just the first
         found = False
         for node in G.nodes:
             if G.nodes[node].get("node_type") == "symptom":
                 if u in node or node in u:
-                    matched_nodes.append(node)
+                    if node not in matched_nodes:  # avoid duplicates
+                        matched_nodes.append(node)
                     found = True
-                    break
+                    # ✅ No break — keep scanning for more matches
         if not found:
             unmatched.append(u)
 

--- a/tests/test_graph_matching.py
+++ b/tests/test_graph_matching.py
@@ -1,0 +1,64 @@
+"""
+tests/test_graph_matching.py
+-----------------------------
+Regression tests for symptom node matching in traverse_graph().
+"""
+
+import pathlib
+import pytest
+
+from app.core.knowledge_graph import load_graph_from_csv, traverse_graph
+
+_CSV = pathlib.Path(__file__).parent.parent / "data" / "symptom_disease.csv"
+
+
+@pytest.fixture(scope="module")
+def graph():
+    if not _CSV.exists():
+        pytest.skip("symptom_disease.csv not found")
+    return load_graph_from_csv(str(_CSV))
+
+
+def test_multiple_symptoms_all_matched(graph):
+    """Regression: early-exit bug — all 3 symptoms must contribute to scoring."""
+    results = traverse_graph(graph, ["fever", "sore throat", "body aches"])
+    assert len(results) > 0
+    # Multiple symptom contributions push raw_score above any single edge weight
+    assert results[0]["raw_score"] > 1.0, (
+        f"raw_score={results[0]['raw_score']} — only one symptom seems to have contributed"
+    )
+
+
+def test_multi_symptom_returns_more_candidates_than_single(graph):
+    results_multi  = traverse_graph(graph, ["fever", "sore throat", "body aches"])
+    results_single = traverse_graph(graph, ["fever"])
+    assert len(results_multi) >= len(results_single)
+
+
+def test_single_symptom_still_works(graph):
+    assert len(traverse_graph(graph, ["fever"])) > 0
+
+
+def test_single_symptom_headache(graph):
+    assert len(traverse_graph(graph, ["headache"])) > 0
+
+
+def test_empty_symptoms_returns_empty(graph):
+    assert traverse_graph(graph, []) == []
+
+
+def test_unrecognised_symptom_returns_empty(graph):
+    assert traverse_graph(graph, ["xyzzy_not_a_real_symptom"]) == []
+
+
+def test_mixed_known_unknown_symptoms(graph):
+    results = traverse_graph(graph, ["fever", "xyzzy_unknown"])
+    assert len(results) > 0
+
+
+def test_duplicate_symptom_no_score_inflation(graph):
+    """Same symptom twice must not double-count its score."""
+    once  = traverse_graph(graph, ["fever"])
+    twice = traverse_graph(graph, ["fever", "fever"])
+    if once and twice:
+        assert once[0]["raw_score"] == twice[0]["raw_score"]


### PR DESCRIPTION
- Removed break after first substring match in traverse_graph()
- All input symptoms now collect every matching graph node, not just the first
- Added duplicate guard (node not in matched_nodes) to prevent score inflation
- Created tests/test_graph_matching.py with 8 regression tests covering: multi-symptom scoring, single-symptom non-regression, edge cases, and duplicate symptom deduplication