### PR TITLE
security: add length and content validation to chat input

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -24,7 +24,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import List, Optional
 from groq import Groq
 from dotenv import load_dotenv
@@ -112,20 +112,20 @@ app.add_middleware(
 # ---------------------------------------------------------------------------
 
 class Message(BaseModel):
-    role: str       # "user" or "model" (Gemini uses "model", but frontend might still send it)
-    content: str
+    role: str = Field(..., pattern="^(user|assistant|model)$")
+    content: str = Field(..., min_length=1, max_length=1000)
 
 class SymptomDetail(BaseModel):
-    name: str
-    onset_order: Optional[int] = None      # 1 = first, 2 = second, etc.
-    duration: Optional[str] = None         # e.g., "3 days", "since morning"
-    severity: Optional[str] = None         # e.g., "mild", "severe"
+    name: str = Field(..., min_length=1, max_length=100)
+    onset_order: Optional[int] = Field(None, ge=1, le=50)
+    duration: Optional[str] = Field(None, max_length=100)
+    severity: Optional[str] = Field(None, max_length=50)
 
 class ChatRequest(BaseModel):
-    messages: List[Message]
-    session_id: Optional[str] = None        # server echoes this back; client stores and re-sends
-    extracted_symptoms: Optional[List[str]] = []  # kept for backwards-compat
-    temporal_context: Optional[List[SymptomDetail]] = [] # New: detailed symptom timing
+    messages: List[Message] = Field(..., max_length=20)
+    session_id: Optional[str] = Field(None, max_length=100)
+    extracted_symptoms: Optional[List[str]] = Field([], max_length=30)
+    temporal_context: Optional[List[SymptomDetail]] = Field([], max_length=30)
 
 class ChatResponse(BaseModel):
     reply: str


### PR DESCRIPTION
### **Summary**
This PR implements robust input validation for the /chat endpoint to address security risks related to Denial of Service (DoS) and Prompt Injection. By leveraging Pydantic’s schema validation, we now intercept and reject malicious or oversized payloads before they reach the NLP processing or LLM logic.

closes issue #9 

### **Changes**
**Message Validation:** Added min_length=1 and max_length=1000 constraints to the message content field.
Role Enforcement: Implemented a regex pattern to ensure only valid roles (user, assistant, model) are accepted.
**Session Protection:** Added a limit of 20 messages per request to prevent context window bloat and excessive resource consumption.
**Metadata Validation:** Enforced length and range limits on SymptomDetail fields (e.g., onset_order limited to 1-50, durations limited to 100 chars).
**Automatic Error Handling:** The system now automatically returns a 422 Unprocessable Entity status code for any validation failure, protecting backend resources.

### **Testing Performed**

Positive Test: Verified that standard conversation turns (under 1000 characters) still work perfectly.
Security Test: I specifically tested the system with a 1000+ character message, and it was correctly blocked by the server with a validation error.
Role Test: Verified that invalid roles (like "doctor" or "hacker") are now rejected.
