### PR TITLE
fix: NameError in /chat endpoint — all_symptoms not defined

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -337,7 +337,10 @@ async def chat(request: ChatRequest):
             noise_message = "I couldn't identify any valid symptoms. Please describe your symptoms clearly."
 
         # Temporal Context Logic
-        all_symptoms_data = merge_symptom_timeline(prior_symptoms, extraction.symptoms)
+        if extraction.symptoms:
+            all_symptoms_data = merge_symptom_timeline(prior_symptoms, extraction.symptoms)
+        else:
+            all_symptoms_data = list(prior_symptoms)
 
         if request.temporal_context:
             for ctx in request.temporal_context:


### PR DESCRIPTION
## Problem
The /chat endpoint referenced `all_symptoms` in two places, but the 
variable defined in the function is `all_symptom_names`. This caused 
a NameError on every request, crashing the endpoint.

The `noise_message` block also had broken indentation — it was outside 
the try block, causing a SyntaxError that prevented the app from starting.

## Fix
- Replaced `all_symptoms` with `all_symptom_names` in:
  - `check_red_flags(GRAPH, all_symptoms)`
  - `extracted_symptoms=all_symptoms` in `build_system_prompt()`
- Fixed indentation of `noise_message` block
- Added fallback `all_symptoms_data = list(prior_symptoms)` when no 
  symptoms are extracted

## Files Changed
- `app/main.py`

Fixes #80 
