### PR TITLE
feat: added automate github ci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,32 @@
+name: Run Tests
+
+on:
+    push:
+        branches:
+            - main
+    pull_request:
+
+permissions:
+    contents: read
+
+jobs:
+    pytest:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+            
+            - name: Set up Python
+              uses: actions/setup-python@v5
+              with:
+                python-version: "3.12"
+                cache: "pip"
+            
+            - name: Install lightweight CI dependencies
+              run: |
+                python -m pip install --upgrade pip
+                pip install pytest networkx
+
+            - name: Run tests
+              run: python -m pytest -q tests


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow to run the existing test suite automatically on pushes to `main` and on all pull requests. closes #76 

## Changes
- added `.github/workflows/tests.yml`
- set up Python 3.12
- installed lightweight dependencies needed by the current tests
- ran tests with `python -m pytest -q tests`

## Why
The repo already has tests, but they were not being run automatically on GitHub. This workflow adds a lightweight CI check so contributors and reviewers can quickly see whether changes affect existing test coverage.

## Note
While validating the workflow, one existing test failure was found in `tests/test_graph_matching.py::test_multiple_symptoms_all_matched`. This appears to be a pre-existing graph traversal/scoring issue in `app/core/knowledge_graph.py`, not a problem with the CI workflow itself.

## Current Status
- CI workflow added
- test execution working
- one existing graph test failure remains to be fixed separately
