### PR TITLE
fix: deduplicate requirements.txt and add minimum version pins

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,24 @@
-groq
-google-genai
-fastapi
-uvicorn[standard]
-python-dotenv
-groq
-google-genai
-fastapi
-uvicorn[standard]
-python-dotenv
-networkx
-rapidfuzz
+# ── Core API & Server ─────────────────────────────────────────────────────────
+fastapi>=0.111.0
+uvicorn[standard]>=0.29.0
+python-dotenv>=1.0.0
 
-# For production-grade RAG (upgrade from TF-IDF):
-sentence-transformers
-scipy
-# chromadb
+# ── LLM Client ────────────────────────────────────────────────────────────────
+groq>=0.9.0
 
-# For production-grade NLP (upgrade from keyword matching):
-spacy
+# ── Knowledge Graph ───────────────────────────────────────────────────────────
+networkx>=3.3
+
+# ── NLP & Fuzzy Matching ──────────────────────────────────────────────────────
+spacy>=3.7.0
+rapidfuzz>=3.6.0
+# After install, download the language model:
 # python -m spacy download en_core_web_sm
+
+# ── RAG / Semantic Retrieval ──────────────────────────────────────────────────
+sentence-transformers>=2.7.0
+scipy>=1.13.0
+# chromadb  # optional: uncomment for persistent vector store
+
+# ── Utilities ─────────────────────────────────────────────────────────────────
+google-genai>=0.5.0


### PR DESCRIPTION
## Problem
`requirements.txt` listed the same packages twice (groq, google-genai,
fastapi, uvicorn, python-dotenv), making it confusing for new contributors
and harder to maintain consistent versions.

## Changes
- Removed all duplicate entries
- Added minimum version pins for key packages (fastapi, uvicorn, groq,
  networkx, spacy, rapidfuzz, sentence-transformers, scipy, google-genai)
- Grouped packages by purpose with section comments for readability
- Moved the spacy model download note next to the spacy package

## Files Changed
- `requirements.txt`

Fixes #75
