### PR TITLE
fix: remove duplicate session storage and update comment

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -63,12 +63,8 @@ NLP = SymptomExtractor(csv_path=_SYMPTOM_CSV)
 print("[startup] Groq client ready.")
 GROQ = Groq(api_key=os.getenv("GROQ_API_KEY"))
 
-# In-memory store for conversational state. Maps session_id -> list of symptoms.
-# In production, use Redis or a database.
-SESSION_STORE = {}
-
 # ---------------------------------------------------------------------------
-# Server-side session store  { session_id -> {symptoms, last_active} }
+# Server-side session store: sessionId -> { symptoms: list[dict], last_active: datetime }
 # Sessions expire after 2 hours of inactivity.
 # ---------------------------------------------------------------------------
 SESSION_STORE: dict[str, dict] = {}


### PR DESCRIPTION
Closes #74

- Removed redundant session storage declaration
- Kept a single clean SESSION_STORE definition
- Updated comment to reflect actual structure:
  sessionId -> { symptoms, last_active }
- Ensured session expiry logic using SESSION_TTL remains intact

This improves code clarity and removes unnecessary duplication.