### PR TITLE
Migrate backend to AsyncGroq architecture

### DIFF
--- a/app/core/error_handler.py
+++ b/app/core/error_handler.py
@@ -148,41 +148,70 @@ def retry_with_backoff(
             ...
     """
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-        @wraps(func)
-        async def wrapper(*args: Any, **kwargs: Any) -> Any:
-            last_exception = None
-            
-            for attempt in range(max_retries + 1):
-                try:
-                    return await func(*args, **kwargs)
-                except Exception as e:
-                    last_exception = e
-                    
-                    # Don't retry on authentication errors
-                    if APIErrorHandler.is_authentication_error(e):
-                        APIErrorHandler.log_error(e, f"Attempt {attempt + 1}/{max_retries + 1}")
-                        raise
-                    
-                    # Only retry on rate limit and connection errors
-                    if not (APIErrorHandler.is_rate_limit_error(e) or 
-                           APIErrorHandler.is_connection_error(e)):
-                        APIErrorHandler.log_error(e, f"Attempt {attempt + 1}/{max_retries + 1}")
-                        raise
-                    
-                    if attempt < max_retries:
-                        # Calculate exponential backoff
-                        delay = min(base_delay * (exponential_base ** attempt), max_delay)
-                        logger.warning(
-                            f"Retrying after {delay}s (attempt {attempt + 1}/{max_retries})... "
-                            f"Error: {type(e).__name__}"
-                        )
-                        await asyncio.sleep(delay)
-                    else:
-                        APIErrorHandler.log_error(e, f"Final attempt {attempt + 1}/{max_retries + 1}")
-            
-            # If all retries exhausted, raise last exception
-            if last_exception:
-                raise last_exception
-        
-        return wrapper
+        if asyncio.iscoroutinefunction(func):
+            @wraps(func)
+            async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                last_exception = None
+                
+                for attempt in range(max_retries + 1):
+                    try:
+                        return await func(*args, **kwargs)
+                    except Exception as e:
+                        last_exception = e
+                        
+                        if APIErrorHandler.is_authentication_error(e):
+                            APIErrorHandler.log_error(e, f"Attempt {attempt + 1}/{max_retries + 1}")
+                            raise
+                        
+                        if not (APIErrorHandler.is_rate_limit_error(e) or 
+                               APIErrorHandler.is_connection_error(e)):
+                            APIErrorHandler.log_error(e, f"Attempt {attempt + 1}/{max_retries + 1}")
+                            raise
+                        
+                        if attempt < max_retries:
+                            delay = min(base_delay * (exponential_base ** attempt), max_delay)
+                            logger.warning(
+                                f"Retrying after {delay}s (attempt {attempt + 1}/{max_retries})... "
+                                f"Error: {type(e).__name__}"
+                            )
+                            await asyncio.sleep(delay)
+                        else:
+                            APIErrorHandler.log_error(e, f"Final attempt {attempt + 1}/{max_retries + 1}")
+                
+                if last_exception:
+                    raise last_exception
+            return async_wrapper
+        else:
+            @wraps(func)
+            def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+                last_exception = None
+                
+                for attempt in range(max_retries + 1):
+                    try:
+                        return func(*args, **kwargs)
+                    except Exception as e:
+                        last_exception = e
+                        
+                        if APIErrorHandler.is_authentication_error(e):
+                            APIErrorHandler.log_error(e, f"Attempt {attempt + 1}/{max_retries + 1}")
+                            raise
+                        
+                        if not (APIErrorHandler.is_rate_limit_error(e) or 
+                               APIErrorHandler.is_connection_error(e)):
+                            APIErrorHandler.log_error(e, f"Attempt {attempt + 1}/{max_retries + 1}")
+                            raise
+                        
+                        if attempt < max_retries:
+                            delay = min(base_delay * (exponential_base ** attempt), max_delay)
+                            logger.warning(
+                                f"Retrying after {delay}s (attempt {attempt + 1}/{max_retries})... "
+                                f"Error: {type(e).__name__}"
+                            )
+                            time.sleep(delay)
+                        else:
+                            APIErrorHandler.log_error(e, f"Final attempt {attempt + 1}/{max_retries + 1}")
+                
+                if last_exception:
+                    raise last_exception
+            return sync_wrapper
     return decorator

--- a/app/core/error_handler.py
+++ b/app/core/error_handler.py
@@ -10,6 +10,7 @@ Supports:
 """
 
 import time
+import asyncio
 from typing import Callable, TypeVar, Any
 from functools import wraps
 import logging
@@ -146,14 +147,14 @@ def retry_with_backoff(
         def call_groq_api():
             ...
     """
-    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> T:
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
             last_exception = None
             
             for attempt in range(max_retries + 1):
                 try:
-                    return func(*args, **kwargs)
+                    return await func(*args, **kwargs)
                 except Exception as e:
                     last_exception = e
                     
@@ -175,7 +176,7 @@ def retry_with_backoff(
                             f"Retrying after {delay}s (attempt {attempt + 1}/{max_retries})... "
                             f"Error: {type(e).__name__}"
                         )
-                        time.sleep(delay)
+                        await asyncio.sleep(delay)
                     else:
                         APIErrorHandler.log_error(e, f"Final attempt {attempt + 1}/{max_retries + 1}")
             

--- a/app/main.py
+++ b/app/main.py
@@ -26,7 +26,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 from typing import List, Optional
-from groq import Groq
+from groq import AsyncGroq
 from dotenv import load_dotenv
 import logging
 
@@ -61,7 +61,7 @@ RAG = RAGPipeline(csv_path=_DOCS_CSV)
 print("[startup] Loading NLP extractor (dynamic lexicon from CSV)...")
 NLP = SymptomExtractor(csv_path=_SYMPTOM_CSV)
 print("[startup] Groq client ready.")
-GROQ = Groq(api_key=os.getenv("GROQ_API_KEY"))
+GROQ = AsyncGroq(api_key=os.getenv("GROQ_API_KEY"))
 
 # In-memory store for conversational state. Maps session_id -> list of symptoms.
 # In production, use Redis or a database.
@@ -295,7 +295,7 @@ FINAL_LINK_THRESHOLD = 0.65
 
 
 @retry_with_backoff(max_retries=2, base_delay=1.0)
-def call_groq_api(messages: list, model: str = "llama-3.1-8b-instant") -> str:
+async def call_groq_api(messages: list, model: str = "llama-3.1-8b-instant") -> str:
     """
     Call Groq API with proper error handling and retry logic.
     
@@ -309,7 +309,7 @@ def call_groq_api(messages: list, model: str = "llama-3.1-8b-instant") -> str:
     Raises:
         Various exceptions with user-friendly handling
     """
-    chat_completion = GROQ.chat.completions.create(
+    chat_completion = await GROQ.chat.completions.create(
         model=model,
         messages=messages,
         max_tokens=1000,
@@ -472,7 +472,7 @@ async def chat(request: ChatRequest):
             messages.append({"role": role, "content": m.content})
 
         try:
-            reply = call_groq_api(messages)
+            reply = await call_groq_api(messages)
             if noise_message:
                 reply = f"{noise_message}\n\n{reply}"
         except Exception as e:


### PR DESCRIPTION
Overview: This PR resolves a major scalability bottleneck by migrating the LLM backend integration from a synchronous blocking architecture to a fully asynchronous, non-blocking architecture.

The Problem: Previously, app/main.py used the synchronous Groq() client inside the FastAPI /chat endpoint. Because FastAPI uses an ASGI event loop, calling a synchronous network function forced the entire web server thread to block and freeze while waiting for the LLM to generate its response. Additionally, the retry_with_backoff decorator in error_handler.py used time.sleep(), which catastrophically blocked the event loop during rate limits.

The Fix:

Swapped Groq() for AsyncGroq().
Converted call_groq_api to an async def function and updated the endpoints to await the response without blocking the event loop.
Refactored the retry_with_backoff error handler to support asynchronous coroutines, replacing the blocking time.sleep(delay) with the non-blocking await asyncio.sleep(delay).

Testing & Verification:

Verified the FastAPI server successfully initializes the Async client and streams completions correctly.
Confirmed the test suite (pytest tests/) passes.