### PR TITLE
fix: exclude negated symptoms from red flag detection

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -361,7 +361,11 @@ async def chat(request: ChatRequest):
         all_symptom_names = [s["name"] for s in all_symptoms_data]
 
         # --- Step 2: Red flag check ---
-        red_flags = check_red_flags(GRAPH, all_symptom_names)
+        safe_symptoms = [
+        s for s in all_symptom_names
+        if s not in extraction.negated
+        ]
+        red_flags = check_red_flags(GRAPH, safe_symptoms)
 
         # --- Step 3: BFS graph traversal ---
         candidates = traverse_graph(GRAPH, all_symptoms_data)


### PR DESCRIPTION
## Problem

If a user says "I don't have chest pain", the system 
still triggers a red flag emergency alert for chest pain.

The NLP extractor correctly detects the negation and 
puts chest pain in extraction.negated — but 
check_red_flags() was receiving the full symptom list,
negated symptoms included.

## Root Cause

In main.py Step 2:
  red_flags = check_red_flags(GRAPH, all_symptom_names)

all_symptom_names contains ALL symptoms regardless of 
negation. extraction.negated is computed but never used
here.

## Fix

Filter negated symptoms before passing to check_red_flags():

  safe_symptoms = [
      s for s in all_symptom_names
      if s not in extraction.negated
  ]
  red_flags = check_red_flags(GRAPH, safe_symptoms)

## Impact

Before: "I don't have chest pain" → triggers 🚨 emergency alert
After:  "I don't have chest pain" → no false alert ✅

## Files Changed

- app/main.py (2 lines added, 1 line changed)