### PR TITLE
feat: add symptom suggestion chips above chat input (#114)

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1026,3 +1026,10 @@
           }
         });
       };
+
+        function sendChip(text) {
+          const input = document.getElementById('input');
+          input.value = text;
+          input.dispatchEvent(new Event('input'));
+          document.getElementById('send-btn').click();
+        }

--- a/static/index.html
+++ b/static/index.html
@@ -92,6 +92,17 @@
         <div id="chat-area"></div>
 
         <footer>
+
+          <!-- Symptom Suggestion Chips -->
+          <div id="suggestion-chips">
+            <button class="chip" onclick="sendChip('Fever and dry cough')"> Fever and dry cough</button>
+            <button class="chip" onclick="sendChip('Sore throat, runny nose, and sneezing')"> Sore throat, runny nose, and sneezing</button>
+            <button class="chip" onclick="sendChip('Severe headache with sensitivity to light')"> Severe headache with sensitivity to light</button>
+            <button class="chip" onclick="sendChip('Lower back pain and morning stiffness')"> Lower back pain and morning stiffness</button>
+            <button class="chip" onclick="sendChip('Stomach bloating and abdominal pain')"> Stomach bloating and abdominal pain</button>
+          </div>
+
+
           <div class="input-wrapper">
             <input
               id="input"

--- a/static/style.css
+++ b/static/style.css
@@ -1420,3 +1420,49 @@
     padding: 0;
   }
 }
+
+
+#suggestion-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  overflow-x: hidden;
+  padding: 8px 0 12px 0;
+}
+
+#suggestion-chips::-webkit-scrollbar {
+  display: none;
+}
+
+/* Replace existing .chip styles with these */
+.chip {
+  flex-shrink: 0;
+  background: rgba(15, 118, 110, 0.08);
+  border: 1px solid rgba(15, 118, 110, 0.25);
+  color: #0f766e;
+  padding: 6px 14px;
+  border-radius: 20px;
+  font-size: 13px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.2s ease, border-color 0.2s ease;
+  font-weight: 600;
+}
+
+.chip:hover {
+  background: rgba(15, 118, 110, 0.16);
+  border-color: rgba(15, 118, 110, 0.5);
+  color: #0d5f58;
+}
+
+.dark-mode .chip {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: #e2e8f0;
+}
+
+.dark-mode .chip:hover {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(99, 202, 183, 0.5);
+  color: #ffffff;
+}


### PR DESCRIPTION
Closes #114

## Changes
- Added a row of 5 symptom suggestion chips above the chat input bar
- Clicking a chip automatically sends the symptom text to the chat
- Chips wrap to the next line on smaller screens (responsive)
- Styled to match the existing Glassmorphism/Dark-Mode aesthetic
- Dark mode support included for chip styles

## Chips Added
1.  Fever and dry cough
2.  Sore throat, runny nose, and sneezing
3.  Severe headache with sensitivity to light
4.  Lower back pain and morning stiffness
5.  Stomach bloating and abdominal pain

## Files Changed
- `static/index.html` — added suggestion chips HTML
- `static/style.css` — added chip styles with dark mode and responsive support
- `static/app.js` — added `sendChip()` function

<img width="1708" height="906" alt="image" src="https://github.com/user-attachments/assets/725b575e-0ff3-419e-b0bf-7343e5dee1c0" />
