### PR TITLE
issue #125 PDF Generation Produces Invalid PDFs Due to Incorrect Obje…

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -321,15 +321,15 @@ def build_pdf_bytes(text: str) -> bytes:
     pages_id = add_object("<< /Type /Pages /Kids [3 0 R] /Count {} >>".format(len(pages)))
     page_ids = []
     content_ids = []
+    font_id = add_object("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>")
     for page in pages:
         content_id = add_object(f"<< /Length {len(page.encode('latin1'))} >>\nstream\n{page}\nendstream")
         content_ids.append(content_id)
     for content_id in content_ids:
         page_id = add_object(
-            f"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 {page_width} {page_height}] /Contents {content_id} 0 R /Resources <</Font <</F1 5 0 R>>>> >>"
+            f"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 {page_width} {page_height}] /Contents {content_id} 0 R /Resources <</Font <</F1 {font_id} 0 R>>>> >>"
         )
         page_ids.append(page_id)
-    font_id = add_object("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>")
 
     # Rebuild pages object with correct kid refs
     pages_obj = f"<< /Type /Pages /Kids [{' '.join(f'{pid} 0 R' for pid in page_ids)}] /Count {len(page_ids)} >>"


### PR DESCRIPTION
Fixed the PDF object reference bug in [main.py](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).

Moved the font object creation before page creation.
Replaced the hardcoded /F1 5 0 R reference with the dynamic [font_id](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).