### PR TITLE
Add /health endpoint for API health checks

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -447,6 +447,10 @@ app.mount("/static", StaticFiles(directory="static"), name="static")
 def index():
     return FileResponse("static/index.html")
 
+@app.get("/health")
+async def health_check():
+    return {"status": "ok", "version": "2.0"}
+
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
# Add `/health` Endpoint for API Health Checks

## Summary

Implemented a health check endpoint for the FastAPI backend to support production readiness and monitoring.


## Fixes #139 


## Changes Made

* Added a new `GET /health` route in `app/main.py`
* Endpoint returns a `200 OK` response
* Added JSON response:

```json
{
  "status": "ok",
  "version": "2.0"
}
```

## Testing

Tested locally using:

```bash
uvicorn app.main:app --reload
```

Verified endpoint at:

```text
http://127.0.0.1:8000/health
```

Received successful response:

```json
{
  "status": "ok",
  "version": "2.0"
}
```

Thank you for reviewing my PR!