### PR TITLE
#143 exception output for the error_log.txt

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -618,7 +618,10 @@ async def chat(request: ChatRequest):
         logging.error("CRITICAL ERROR IN /chat ENDPOINT:")
         logging.error(err_msg)
         APIErrorHandler.log_error(overall_e, "Critical error in /chat endpoint")
-        with open("error_log.txt", "w", encoding="utf-8") as f:
+        logs_path = _PROJECT_ROOT / "logs"
+        logs_path.mkdir(parents=True, exist_ok=True)
+        error_log_path = logs_path / "error.log"
+        with open(error_log_path, "w", encoding="utf-8") as f:
             f.write(err_msg)
         raise HTTPException(status_code=500, detail=APIErrorHandler.get_user_message(overall_e)) from overall_e
 


### PR DESCRIPTION
Updating the exception handler so critical failures go to the app’s dedicated [logs](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) folder instead of a relative file. 

- [main.py](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) now writes the [/chat](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) exception dump to:
[error.log](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

- instead of a working-directory-relative [error_log.txt](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).

This keeps error output consistent with the app’s existing logging folder and avoids stray files appearing in random directories.