### PR TITLE
Fix missing base64 import in FastAPI endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -16,6 +16,7 @@ Dataset-driven: conditions, symptoms, and documents all come from
 """
 
 import os
+import base64
 import json
 import uuid
 import pathlib


### PR DESCRIPTION
## Fix: Missing base64 Import in FastAPI Endpoints

This PR fixes the runtime error occurring when users upload audio or image symptoms through the `/input/audio` and `/input/vision` endpoints.

### Changes Made

* Added `import base64` to `app/main.py`

### Result

* Prevents `NameError` caused by missing `base64` import
* Ensures audio and image uploads are processed correctly
