### PR TITLE
fix(security): require admin token for POST /cache/clear and rate-limit GET /summary

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -721,15 +721,26 @@ async def cache_stats():
     return SEMANTIC_CACHE.stats()
 
 
+def _require_admin_key(request: Request) -> None:
+    """Raise 401 when the X-Admin-Token header does not match CACHE_ADMIN_KEY."""
+    expected = os.getenv("CACHE_ADMIN_KEY")
+    if not expected:
+        raise HTTPException(status_code=503, detail="Admin key not configured")
+    if request.headers.get("X-Admin-Token") != expected:
+        raise HTTPException(status_code=401, detail="Invalid or missing admin token")
+
+
 @app.post("/cache/clear")
-async def cache_clear():
-    """Manually wipe the entire semantic cache."""
+async def cache_clear(request: Request):
+    """Wipe the entire semantic cache. Requires X-Admin-Token header."""
+    _require_admin_key(request)
     SEMANTIC_CACHE.clear()
     return {"cleared": True}
 
 
 @app.get("/summary/{session_id}", response_model=SummaryResponse)
-async def get_summary(session_id: str):
+@limiter.limit("30/minute")
+async def get_summary(request: Request, session_id: str):
     """Generates a stable, clinical summary for the given session."""
     if session_id not in SESSION_STORE:
         raise HTTPException(status_code=404, detail="Session not found or expired")


### PR DESCRIPTION
## Description

Two endpoints in `app/main.py` were fully unauthenticated, exposing sensitive operations to any HTTP caller with no credentials:

**POST /cache/clear** -- Any anonymous request could wipe the entire shared semantic cache. This is a denial-of-service vector: a single HTTP call degrades response quality and increases latency for every active user simultaneously with no rate limit or auth required.

**GET /summary/{session_id}** -- The endpoint returned the full medical session contents (symptom timeline, matched conditions, red flags, RAG sources) to any caller who knew or guessed the session UUID. There was no throttle to slow enumeration attempts against predictable or leaked IDs.

## Related Issues

Closes #159

## Type of Change

- [x] Bug fix (security)

## Changes Made

- **`app/main.py`**: Added `_require_admin_key(request)` helper that reads the `CACHE_ADMIN_KEY` environment variable and compares it against the incoming `X-Admin-Token` header. Returns `401` on mismatch and `503` when the variable is not configured, preventing silent fail-open behaviour.
- **`app/main.py`**: Applied `_require_admin_key()` to `POST /cache/clear` by adding a `request: Request` parameter and calling the helper at the start of the handler.
- **`app/main.py`**: Added `@limiter.limit("30/minute")` to `GET /summary/{session_id}` using the existing `slowapi` `Limiter` instance already wired to the app. Added `request: Request` as the first parameter to satisfy the `slowapi` decorator requirement.

## Screenshots / Demo

Not applicable. Backend security fix with no UI change.

## Testing Done

**POST /cache/clear:**
1. Start the server without `CACHE_ADMIN_KEY` set. Send `POST /cache/clear`. Confirm `503` is returned.
2. Set `CACHE_ADMIN_KEY=secret`. Send `POST /cache/clear` without the header. Confirm `401`.
3. Send `POST /cache/clear` with `X-Admin-Token: secret`. Confirm `200 {"cleared": true}`.

**GET /summary/{session_id}:**
1. Start a chat session via `POST /chat` and note the returned `session_id`.
2. Send `GET /summary/{session_id}`. Confirm the summary is returned as before.
3. Send 31 requests within one minute. Confirm the 31st returns `429 Too Many Requests`.

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its guidelines
- [x] I have read the CODE_OF_CONDUCT.md
- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue
- [x] I have not used any AI-generated content in this PR

---

Could you please add the appropriate **NSoC '26** label to this PR? It helps with tracking and scoring under NSoC '26. Thank you!