### PR TITLE
fix(session): cap SESSION_STORE at a configurable max to prevent memory exhaustion

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -108,6 +108,7 @@ def _get_groq_client():
 # ---------------------------------------------------------------------------
 SESSION_STORE: dict[str, dict] = {}
 SESSION_TTL = timedelta(hours=2)
+SESSION_STORE_MAX = int(os.getenv("SESSION_STORE_MAX", "5000"))
 
 
 def _get_or_create_session(session_id: str | None) -> tuple[str, list[dict]]:
@@ -116,6 +117,11 @@ def _get_or_create_session(session_id: str | None) -> tuple[str, list[dict]]:
     if session_id and session_id in SESSION_STORE:
         SESSION_STORE[session_id]["last_active"] = datetime.utcnow()
         return session_id, SESSION_STORE[session_id]["symptoms"]
+    # Evict the oldest session when the store is at capacity so the dict
+    # cannot grow without bound on a long-running server.
+    if len(SESSION_STORE) >= SESSION_STORE_MAX:
+        oldest_id = min(SESSION_STORE, key=lambda sid: SESSION_STORE[sid]["last_active"])
+        del SESSION_STORE[oldest_id]
     new_id = str(uuid.uuid4())
     SESSION_STORE[new_id] = {"symptoms": [], "last_active": datetime.utcnow()}
     return new_id, []


### PR DESCRIPTION
## Description

`SESSION_STORE` (line 109) was an unbounded Python `dict` with no upper limit on the number of entries. The existing `_purge_expired_sessions()` function removes sessions inactive for 2 hours, but it is called only lazily inside `_get_or_create_session()`. An attacker sending rapid requests without a `session_id` -- or with unique IDs on each call -- creates a new dict entry per request, accumulating entries faster than the TTL-based cleanup can remove them. Under sustained traffic this fills the server heap and causes an out-of-memory crash for all users.

## Related Issues

Closes #160

## Type of Change

- [x] Bug fix (denial-of-service / resource exhaustion)

## Changes Made

- **`app/main.py`**: Added `SESSION_STORE_MAX` constant (default `5000`, overridable via the `SESSION_STORE_MAX` environment variable) directly below `SESSION_TTL`.
- **`app/main.py`**: Added a capacity check in `_get_or_create_session()`. When `len(SESSION_STORE) >= SESSION_STORE_MAX`, the entry with the oldest `last_active` timestamp is evicted before the new session is inserted. This keeps the dict bounded at all times while preserving the most recently active sessions.

## Screenshots / Demo

Not applicable. This is a backend resource-management fix with no UI change.

## Testing Done

1. Set `SESSION_STORE_MAX=3` in the environment and start the server.
2. Send 4 `POST /chat` requests, each without a `session_id` (or with a unique one).
3. Inspect `SESSION_STORE` after each request. After the 4th request confirm the dict still has exactly 3 entries and the oldest entry was removed.
4. Confirm normal chat flow continues to work -- existing sessions with a matching `session_id` are still returned correctly.
5. Remove the `SESSION_STORE_MAX` override and confirm the default of `5000` is applied.

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its guidelines
- [x] I have read the CODE_OF_CONDUCT.md
- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue
- [x] I have not used any AI-generated content in this PR

---

Could you please add the appropriate **NSoC '26** label to this PR? It helps with tracking and scoring under NSoC '26. Thank you!