### PR TITLE
fix(cors): restrict CORS origins to env-configured domains and narrow allowed methods

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -142,11 +142,16 @@ app = FastAPI(title="SymptomAssist AI", version="2.0")
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
+_CORS_ORIGINS = [
+    o.strip()
+    for o in os.getenv("CORS_ORIGINS", "http://localhost:5173,http://localhost:8000").split(",")
+    if o.strip()
+]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_origins=_CORS_ORIGINS,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["Content-Type", "Authorization", "X-Admin-Token"],
 )
 
 


### PR DESCRIPTION
## Description

`app/main.py` configured `CORSMiddleware` with `allow_origins=["*"]`, `allow_methods=["*"]`, and `allow_headers=["*"]`. This told every browser that any website is allowed to make cross-origin requests to the SymptomAssist API and read the full response -- including medical symptom data and session content.

`allow_methods=["*"]` also implicitly permitted `DELETE`, `PUT`, and `PATCH` at the CORS pre-flight level, even though the API only defines `GET` and `POST` routes.

## Related Issues

Closes #161

## Type of Change

- [x] Bug fix (security)

## Changes Made

- **`app/main.py`**: Added `_CORS_ORIGINS` list built from the `CORS_ORIGINS` environment variable (comma-separated string). Falls back to `http://localhost:5173,http://localhost:8000` for local development. Production deployments must set `CORS_ORIGINS` to the actual frontend domain.
- **`app/main.py`**: Changed `allow_origins` from `["*"]` to `_CORS_ORIGINS`.
- **`app/main.py`**: Changed `allow_methods` from `["*"]` to `["GET", "POST", "OPTIONS"]` -- the only methods the API actually uses.
- **`app/main.py`**: Changed `allow_headers` from `["*"]` to the specific headers the API uses: `Content-Type`, `Authorization`, and `X-Admin-Token`.

## Screenshots / Demo

Not applicable. Backend configuration change with no UI impact.

## Testing Done

1. Start the server with `CORS_ORIGINS=https://myapp.example.com`.
2. From a browser on a different origin, send `POST /chat`. Confirm the browser blocks the response (CORS rejected).
3. From the same origin, confirm the request succeeds.
4. Send a pre-flight `OPTIONS` request with `Origin: http://localhost:5173` (default). Confirm `Access-Control-Allow-Origin: http://localhost:5173` is returned.
5. Send a pre-flight with `Access-Control-Request-Method: DELETE`. Confirm it is not listed in the response's `Access-Control-Allow-Methods`.

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its guidelines
- [x] I have read the CODE_OF_CONDUCT.md
- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue
- [x] I have not used any AI-generated content in this PR

---

Could you please add the appropriate **NSoC '26** label to this PR? It helps with tracking and scoring under NSoC '26. Thank you!