### PR TITLE
fix: header background stays white in dark mode

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -400,6 +400,14 @@
     background: #1e293b !important;
     color: #14b8a6 !important;
   }
+    body.dark-mode header {
+    background: #0f172a !important;
+    border-bottom: 1px solid #1e293b !important;
+  }
+
+  body.dark-mode header .brand-text h1 {
+    color: #f8fafc !important;
+  }
 </style>
   </body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -119,23 +119,27 @@
 
           <div class="input-wrapper">
             <input type="file" id="vision-upload-input" accept="image/*" style="display: none;" />
+
+            <button id="vision-btn" class="multimodal-btn" type="button" title="Upload symptom image"
+  style="width:52px;height:52px;border:none;background:transparent;padding:0;display:flex;align-items:center;justify-content:center;cursor:pointer;color:#64748b;border-radius:8px;outline:none;box-shadow:none;margin: 0;">
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+    <circle cx="8.5" cy="8.5" r="1.5"/>
+    <polyline points="21 15 16 10 5 21"/>
+  </svg>
+</button>
+
+<button id="audio-btn" class="multimodal-btn" type="button" title="Record voice description"
+  style="width:52px;height:52px;border:none;background:transparent;padding:0;display:flex;align-items:center;justify-content:center;cursor:pointer;color:#64748b;border-radius:8px;outline:none;box-shadow:none;margin-left: -12px;">
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/>
+    <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
+    <line x1="12" y1="19" x2="12" y2="23"/>
+    <line x1="8" y1="23" x2="16" y2="23"/>
+  </svg>
+</button>
             
-            <button id="vision-btn" class="multimodal-btn" type="button" title="Upload symptom image">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
-                <circle cx="8.5" cy="8.5" r="1.5"/>
-                <polyline points="21 15 16 10 5 21"/>
-              </svg>
-            </button>
-            
-            <button id="audio-btn" class="multimodal-btn" type="button" title="Record voice description">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/>
-                <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
-                <line x1="12" y1="19" x2="12" y2="23"/>
-                <line x1="8" y1="23" x2="16" y2="23"/>
-              </svg>
-            </button>
+     
 
             <input
               id="input"
@@ -383,5 +387,19 @@
     </div>
 
     <script src="/static/app.js"></script>
+  <!-- Add this in your <head> or just above </body> -->
+<style>
+  #vision-btn:hover,
+  #audio-btn:hover {
+    background: #98e9e254 !important;
+    color: #0f766e !important;
+  }
+
+  .dark-mode #vision-btn:hover,
+  .dark-mode #audio-btn:hover {
+    background: #1e293b !important;
+    color: #14b8a6 !important;
+  }
+</style>
   </body>
 </html>


### PR DESCRIPTION
### Summary
The header was remaining white (`rgb(255, 255, 255)`) when dark mode was active, despite the rest of the app correctly switching to dark backgrounds. This created a jarring visual inconsistency at the top of the UI. Fixes issue #154 

### Root Cause
The global `header` CSS rule was winning over `.dark-mode header` due to CSS specificity. Even though `--chat-bg` was correctly overridden in `.dark-mode`, the computed background on the header stayed white because another rule with equal or higher specificity was overriding it.

### Fix
Added `body.dark-mode header` with `!important` at the bottom of the stylesheet, ensuring it wins over all other conflicting rules regardless of specificity order:

```css
body.dark-mode header {
  background: #0f172a !important;
  border-bottom: 1px solid #1e293b !important;
}

body.dark-mode header .brand-text h1 {
  color: #f8fafc !important;
}
```
### Before
- Header background: `rgb(255, 255, 255)` in dark mode ❌
- Visually broken — white header on dark background

### After
- Header background: `#0f172a` in dark mode ✅
- Consistent dark theme across the entire UI

### Screenshots
## Before
<img width="1920" height="1080" alt="Screenshot (345)" src="https://github.com/user-attachments/assets/ef22c665-9559-4dbc-b9c9-e8eb049dbc00" />


## AFTER
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0e02b8ba-54e9-49ae-86fc-1d0f98f27bb1" />


### Type of Change
- [x] Bug fix (visual/UI)

### Checklist
- [x] Tested in dark mode
- [x] Tested in light mode (no regression)
- [x] No existing functionality broken
- [x] Header text color updated for dark mode readability