### PR TITLE
added "Clear all" button to dismiss suggestion chips

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -114,7 +114,13 @@
             <button class="chip" onclick="sendChip('Severe headache with sensitivity to light')"> Severe headache with sensitivity to light</button>
             <button class="chip" onclick="sendChip('Lower back pain and morning stiffness')"> Lower back pain and morning stiffness</button>
             <button class="chip" onclick="sendChip('Stomach bloating and abdominal pain')"> Stomach bloating and abdominal pain</button>
-          </div>
+
+            <button 
+  onclick="document.getElementById('suggestion-chips').style.display='none'"
+  style="background: none; border: 1.5px solid #ccc; border-radius: 999px; padding: 6px 14px; cursor: pointer; font-size: 13px; color: #888;">
+  ✕ Clear all
+</button>
+</div>
 
 
           <div class="input-wrapper">


### PR DESCRIPTION
## Summary
Fixes issue #155 Added a "Clear all" button inside the suggestion chips container so users can dismiss all chips at once with a single click.

## Changes
- Added a "Clear all" button inside `#suggestion-chips` container
- Applied inline styling directly on the button element
- Added hover styles for both light and dark mode using 
  `prefers-color-scheme: dark` media query in the stylesheet

## How to Test
1. Open the chat interface
2. Confirm suggestion chips are visible on load
3. Click "✕ Clear all"  all chips should disappear instantly
4. Test in light mode and dark mode hover effect should work in both

## Before
<img width="1456" height="819" alt="image" src="https://github.com/user-attachments/assets/e6816329-8f2d-459f-bf3e-f5f98d429f24" />


## After
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/dfb243b4-af93-4736-9418-e291cdce758d" />